### PR TITLE
GameDB: SOCOM 3 + Combined Assault (+ include Sun Fix patch)

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -7663,6 +7663,12 @@ SCUS-97545:
   compat: 5
   clampModes:
     vuClampMode: 3 # Fixes SPS ingame and prevents flickering or invisible characters.
+  patches:
+    D7CFDCCF:
+      content: |-
+        author=Prafull
+        //Fix Slowdown when looking at sun (all Patches)
+        patch=1,EE,0019f480,word,00000000
 SCUS-97548:
   name: "Ape Escape 3 [Demo]"
   region: "NTSC-U"


### PR DESCRIPTION
Works on Game Patches v1.0 & v1.4 on the NTSC version of the game.

Credit to Prafull for making the patch.

### Description of Changes
Include Sun Fix Patch by prafull.  
This will prevent slow downs when looking at the sun on certain maps. The patch will draw a spider web over the sun

### Rationale behind Changes
Improve upon the games playability. The SOCOM series has around 30-70 players who log on to play the game online daily.

### Suggested Testing Steps
Launch the game without the patch and load up "Back Woods" or "Harvester", upon looking up at the sun your game will slow down to a non playable state. 

Apply the patch and the game becomes responsive again